### PR TITLE
138 Added sentry to doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
-0.2.13
+0.2.14
 
 ## Current
+
+**0.2.14 - 2022-07-26**
+
+Features:
+ - Adds sentry integration
+ - Adds django-environ to allow environment variables for Django settings
+
+## Previous Versions
 
 **0.2.13 - 2022-06-02**
 
@@ -10,9 +18,6 @@ This release is focused on performance improvements and easier scaling. It:
  - Sets the number of gunicorn workers to 1 by default. This makes it so that scaling is can be moved to k8s instead of gunicorn.
  - Tells tesseract not to look for white text on black backgrounds. This is just a simple performance tweak.
  - Upgrades to PyPDF2 version 2.0.0.
-
-
-## Previous Versions
 
 **0.2.12 - 2022-05-19**
 

--- a/README.md
+++ b/README.md
@@ -228,3 +228,11 @@ This returns the audio file as a file response.
 
 Testing is designed to be run with the `docker-compose.dev.yml` file.  To see more about testing
 checkout the DEVELOPING.md file.
+
+## Sentry Logging
+
+For debugging purposes, it's possible to set your Sentry DSN to send events to Sentry.
+By default, no SENTRY_DSN is set and no events will be sent to Sentry.
+To use Sentry set the SENTRY_DSN environment variable to your DSN. Using Docker you can set it with:
+
+    docker run -d -p 5050:5050 -e SENTRY_DSN=<https://yout-sentry-dsn> freelawproject/doctor:latest

--- a/doctor/settings.py
+++ b/doctor/settings.py
@@ -9,8 +9,13 @@ https://docs.djangoproject.com/en/4.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.0/ref/settings/
 """
+import environ
+import sentry_sdk
 
 from pathlib import Path
+from sentry_sdk.integrations.django import DjangoIntegration
+
+env = environ.FileAwareEnv()
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 DEBUG = False
@@ -19,3 +24,14 @@ ALLOWED_HOSTS = ["cl-doctor", "0.0.0.0", "localhost"]
 INSTALLED_APPS = []
 ROOT_URLCONF = "doctor.urls"
 WSGI_APPLICATION = "doctor.wsgi.application"
+
+
+SENTRY_DSN = env("SENTRY_DSN", default="")
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[
+            DjangoIntegration(),
+        ],
+        ignore_errors=[KeyboardInterrupt],
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,9 @@ pkginfo==1.5.0.1
 PyPDF2>=1.26.0
 pytesseract>=0.3.5
 requests>=2.25.0
-sentry-sdk[flask]
 six>=1.15.0
 urllib3>=1.25.10
 reportlab
 seal-rookery>=2.2.1
+sentry-sdk
+django-environ>=0.8.1


### PR DESCRIPTION
@mlissner added Sentry to Doctor, it was necessary to add `environ` so that we can retrieve the `SENTRY_DSN` env variable.

I deleted `sentry-sdk[flask]` from requirements.txt, I think it was outdated right?

I tested it locally and it worked by adding the env variable when running the container:

`docker run -d -p 5050:5050 -e SENTRY_DSN=https://the_sentry_dsn freelawproject/doctor:latest`

would this be enough so you can add the SENTRY_DSN as an env variable on Kubernetes?

I had to fork the repository since seems I don't have permission to add a new branch to the original doctor repository. I also couldn't assign reviewers.