### PR TITLE
fix(deps): Adds support for AES-encrypted PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
-0.2.14
-
 ## Current
+
+**0.2.15 - 2022-07-27**
+
+Fixes:
+ - Adds PyCryptodome in order to handle encrypted PDFs ([144](https://github.com/freelawproject/doctor/issues/144))
+
+## Previous Versions
 
 **0.2.14 - 2022-07-26**
 
 Features:
  - Adds sentry integration
  - Adds django-environ to allow environment variables for Django settings
-
-## Previous Versions
 
 **0.2.13 - 2022-06-02**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==3.2.6
 gunicorn==20.1.0
-PyPDF2
+PyPDF2[crypto]
 Pillow
 requests
 pdf2image
@@ -19,7 +19,6 @@ pdf2image>=1.7.1
 pdfplumber
 Pillow>=8.0.1
 pkginfo==1.5.0.1
-PyPDF2>=1.26.0
 pytesseract>=0.3.5
 requests>=2.25.0
 six>=1.15.0


### PR DESCRIPTION
We did not previously install PyCryptodome, a dependency that's needed by pypdf2 to handle encrypted PDFs. Now we do.