### PR TITLE
Increased gunicorn timeout to 90 minutes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,5 +39,5 @@ CMD gunicorn doctor.wsgi:application \
       --workers ${DOCTOR_WORKERS:-1} \
       --max-requests 1000 \
       --max-requests-jitter 100 \
-      --timeout 3600 \
+      --timeout 5400 \
       --bind 0.0.0.0:5050


### PR DESCRIPTION
Seems that we continue getting some `ConnectionError` errors from doctor, specifically related to large documents that need to be extracted via OCR.

E.G: https://com-courtlistener-storage.s3.us-west-2.amazonaws.com/recap/gov.uscourts.flmd.255380/gov.uscourts.flmd.255380.1.0_16.pdf

Increased `gunicorn` timeout to 90 minutes so it matches the doctor's OCR request timeout on CL.