### PR TITLE
feat(thumbnail): Add multipage thumbnail support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Current
 
+**0.3.1 - 2023-01-17**
+
+Features:
+ - Adds /convert/pdf/thumbnails/ service that returns a zip file with thumbnails from a PDF document.
+
+## Previous Versions
+
 **0.3.0 - 2022-09-30**
 
 Features:
@@ -21,8 +28,6 @@ Changes:
      - `/convert-audio/`: Use `/convert/audio/mp3/` instead.
      - `/document/thumbnail/`: Use `/convert/pdf/thumbnail/` instead.
  - Tweaks the tests to use new container names that are less likely to conflict with existing containers.
-
-## Previous Versions
 
 **0.2.16 - 2022-09-28**
 

--- a/README.md
+++ b/README.md
@@ -216,9 +216,10 @@ Keep in mind that this curl will also write the file to the current directory.
 Give a PDF and a range or pages, this endpoint will return a zip file containing thumbnails
 for each page requested.  For example if you want thumbnails for the first four pages:
 
-    curl 'http://localhost:5050/convert/pdf/thumbnails/?max_dimension=350&pages=%5B1%2C+2%2C+3%2C+4%5D' \
+    curl 'http://localhost:5050/convert/pdf/thumbnails/' \
      -X 'POST' \
      -F "file=@doctor/test_assets/vector-pdf.pdf" \
+     -F 'pages="[1,2,3,4]"'
      -o thumbnails.zip
 
 This will return four thumbnails in a zip file.

--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ For example if you want thumbnails for the first four pages:
     curl 'http://localhost:5050/convert/pdf/thumbnails/' \
      -X 'POST' \
      -F "file=@doctor/test_assets/vector-pdf.pdf" \
-     -F 'pages="[1,2,3,4]"'
-     -F 'max_dimension=350'
+     -F 'pages="[1,2,3,4]"' \ 
+     -F 'max_dimension=350' \
      -o thumbnails.zip
 
 This will return four thumbnails in a zip file.

--- a/README.md
+++ b/README.md
@@ -213,13 +213,18 @@ Keep in mind that this curl will also write the file to the current directory.
 
 ### Endpoint: /convert/pdf/thumbnails/
 
-Give a PDF and a range or pages, this endpoint will return a zip file containing thumbnails
-for each page requested.  For example if you want thumbnails for the first four pages:
+Given a PDF and a range or pages, this endpoint will return a zip file containing thumbnails
+for each page requested. This endpoint also takes an optional parameter called max_dimension, 
+this property scales the long side of each thumbnail (width for landscape pages, height for 
+portrait pages) to fit in the specified number of pixels.
+
+For example if you want thumbnails for the first four pages:
 
     curl 'http://localhost:5050/convert/pdf/thumbnails/' \
      -X 'POST' \
      -F "file=@doctor/test_assets/vector-pdf.pdf" \
      -F 'pages="[1,2,3,4]"'
+     -F 'max_dimension=350'
      -o thumbnails.zip
 
 This will return four thumbnails in a zip file.

--- a/doctor/forms.py
+++ b/doctor/forms.py
@@ -4,6 +4,7 @@ import uuid
 
 from django import forms
 from django.core.exceptions import ValidationError
+from django.core.validators import FileExtensionValidator
 
 
 class BaseAudioFile(forms.Form):
@@ -74,7 +75,11 @@ class MimeForm(forms.Form):
 
 
 class ThumbnailForm(forms.Form):
-    file = forms.FileField(label="document", required=True)
+    file = forms.FileField(
+        label="document",
+        required=True,
+        validators=[FileExtensionValidator(["pdf"])],
+    )
     max_dimension = forms.IntegerField(label="max-dimension", required=False)
     pages = forms.Field(label="pages", required=False)
 

--- a/doctor/tests.py
+++ b/doctor/tests.py
@@ -214,13 +214,10 @@ class ThumbnailTests(unittest.TestCase):
                 f.write(response.content)
             with ZipFile(tmp.name, "r") as zipObj:
                 listOfiles = sorted(zipObj.namelist())
-        self.assertEqual(
-            len(listOfiles), 4, msg="Failed to generate thumbnails"
-        )
+        self.assertEqual(len(listOfiles), 4)
         self.assertEqual(
             ["thumb-1.png", "thumb-2.png", "thumb-3.png", "thumb-4.png"],
             listOfiles,
-            msg="thumbnails not generated",
         )
 
 

--- a/doctor/tests.py
+++ b/doctor/tests.py
@@ -4,6 +4,7 @@ import glob
 import unittest
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from zipfile import ZipFile
 
 import eyed3
 import requests
@@ -193,6 +194,34 @@ class ThumbnailTests(unittest.TestCase):
             "http://doctor:5050/convert/pdf/thumbnail/", files=files
         )
         self.assertEqual(response.status_code, 400, msg="Wrong status code")
+
+    def test_thumbnail_range(self):
+        """Can we generate a thumbnail for a range of pages?"""
+        files = make_file(filename="vector-pdf.pdf")
+        pages = [1, 2, 3, 4]
+        data = {
+            "max_dimension": 350,
+            "pages": json.dumps(pages),
+        }
+
+        response = requests.post(
+            "http://doctor:5050/convert/pdf/thumbnails/",
+            files=files,
+            data=data,
+        )
+        with NamedTemporaryFile(suffix=".zip") as tmp:
+            with open(tmp.name, "wb") as f:
+                f.write(response.content)
+            with ZipFile(tmp.name, "r") as zipObj:
+                listOfiles = sorted(zipObj.namelist())
+        self.assertEqual(
+            len(listOfiles), 4, msg="Failed to generate thumbnails"
+        )
+        self.assertEqual(
+            ["thumb-1.png", "thumb-2.png", "thumb-3.png", "thumb-4.png"],
+            listOfiles,
+            msg="thumbnails not generated",
+        )
 
 
 class MetadataTests(unittest.TestCase):

--- a/doctor/urls.py
+++ b/doctor/urls.py
@@ -13,6 +13,11 @@ urlpatterns = [
     path("convert/image/pdf/", views.image_to_pdf, name="image-to-pdf"),
     path("convert/images/pdf/", views.images_to_pdf, name="images-to-pdf"),
     path("convert/pdf/thumbnail/", views.make_png_thumbnail, name="thumbnail"),
+    path(
+        "convert/pdf/thumbnails/",
+        views.make_png_thumbnails_from_range,
+        name="thumbnails",
+    ),
     path("convert/audio/mp3/", views.convert_audio, name="convert-audio"),
     path("utils/page-count/pdf/", views.page_count, name="page_count"),
     path("utils/mime-type/", views.extract_mime_type, name="mime_type"),

--- a/doctor/views.py
+++ b/doctor/views.py
@@ -152,20 +152,19 @@ def make_png_thumbnails_from_range(request) -> HttpResponse:
         return HttpResponse("Failed validation", status=BAD_REQUEST)
 
     directory = TemporaryDirectory()
+    with NamedTemporaryFile(suffix=".pdf", mode="r+b") as temp_pdf:
+        temp_pdf.write(form.cleaned_data["file"].read())
 
-    tmp_file = NamedTemporaryFile(suffix=".pdf")
-    with open(tmp_file.name, "wb") as f:
-        f.write(form.cleaned_data["file"].read())
+        make_png_thumbnails(
+            temp_pdf.name,
+            form.cleaned_data["max_dimension"],
+            form.cleaned_data["pages"],
+            directory,
+        )
 
-    make_png_thumbnails(
-        tmp_file.name,
-        form.cleaned_data["max_dimension"],
-        form.cleaned_data["pages"],
-        directory,
-    )
-    with NamedTemporaryFile(suffix=".zip") as tmp:
+    with NamedTemporaryFile(suffix=".zip") as tmp_zip:
         filename = shutil.make_archive(
-            f"{tmp.name[:-4]}", "zip", directory.name
+            f"{tmp_zip.name[:-4]}", "zip", directory.name
         )
         return FileResponse(open(filename, "rb"))
 

--- a/doctor/views.py
+++ b/doctor/views.py
@@ -1,7 +1,7 @@
 import os
 import re
 from http.client import BAD_REQUEST, INTERNAL_SERVER_ERROR
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Union
 
 import img2pdf
@@ -9,6 +9,7 @@ import magic
 import mimetypes
 import pytesseract
 import requests
+import shutil
 from django.http import FileResponse, HttpResponse, JsonResponse
 from PIL import Image
 from PyPDF2 import PdfReader, PdfWriter
@@ -28,6 +29,7 @@ from doctor.forms import (
 from doctor.lib.utils import (
     cleanup_form,
     make_page_with_text,
+    make_png_thumbnails,
     make_png_thumbnail_for_instance,
     strip_metadata_from_path,
 )
@@ -137,6 +139,35 @@ def make_png_thumbnail(request) -> HttpResponse:
             tmp.name, form.cleaned_data["max_dimension"]
         )
         return HttpResponse(thumbnail)
+
+
+def make_png_thumbnails_from_range(request) -> HttpResponse:
+    """Make a zip file that contains a thumbnail for each page requested.
+
+    :return: A response containing our zip and any errors
+    :type: HTTPS response
+    """
+    form = ThumbnailForm(request.POST, request.FILES)
+    if not form.is_valid():
+        return HttpResponse("Failed validation", status=BAD_REQUEST)
+
+    directory = TemporaryDirectory()
+
+    tmp_file = NamedTemporaryFile(suffix=".pdf")
+    with open(tmp_file.name, "wb") as f:
+        f.write(form.cleaned_data["file"].read())
+
+    make_png_thumbnails(
+        tmp_file.name,
+        form.cleaned_data["max_dimension"],
+        form.cleaned_data["pages"],
+        directory,
+    )
+    with NamedTemporaryFile(suffix=".zip") as tmp:
+        filename = shutil.make_archive(
+            f"{tmp.name[:-4]}", "zip", directory.name
+        )
+        return FileResponse(open(filename, "rb"))
 
 
 def page_count(request) -> HttpResponse:


### PR DESCRIPTION
This PR adds support generating multiple thumbnails from a PDF and resolves https://github.com/freelawproject/doctor/issues/126.

This new service returns a .zip file containing thumbnails for each page requested.
