### PR TITLE
Improve library development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DEBUG=on

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,16 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Create the .env settings file
+      run: cp .env.example .env.dev
+
+    - name: Update .env.dev file
+      run: |
+        echo 'DEBUG=on' >> .env.dev
+
     - name: Build Image
       run: docker-compose -f docker-compose.dev.yml up --build -d
+
     - name: Run tests
       run: docker exec mock_web_app python3 -m unittest doctor.tests

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignore JetBrains files
+.idea
+
+# Env file
+.env.dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,10 +6,20 @@ services:
     build:
       dockerfile: docker/Dockerfile
       context: .
+      args:
+        options: --reload
     image: freelawproject/doctor:latest
+
+
 
   mock_web_app:
     container_name: mock_web_app
     image: freelawproject/doctor:latest
     depends_on:
       - doctor
+    ports:
+      - "5050:5050"
+    volumes:
+      - .:/opt/app
+    env_file:
+      - .env.dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,11 @@ COPY manage.py /opt/app/
 WORKDIR /opt/app
 
 EXPOSE 5050
-CMD gunicorn doctor.wsgi:application \
+
+ARG options
+ENV OPTIONS $options
+
+CMD gunicorn $OPTIONS doctor.wsgi:application \
       --workers ${DOCTOR_WORKERS:-1} \
       --max-requests 1000 \
       --max-requests-jitter 100 \

--- a/doctor/settings.py
+++ b/doctor/settings.py
@@ -18,7 +18,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 env = environ.FileAwareEnv()
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-DEBUG = False
+DEBUG = env.bool("DEBUG", default=False)
 SECRET_KEY = "this-is-a-not-so-secret-key"
 ALLOWED_HOSTS = ["doctor", "0.0.0.0", "localhost"]
 INSTALLED_APPS = []


### PR DESCRIPTION
I implemented a few things that may be useful for developers:

- Allow code reload (you currently need to rebuild the image to test your changes)
- Allow use .env file to set DEBUG to true or false (useful when testing the microservices)
- Map mock web app to be accessible via localhost for testing microservices endpoints updating docker-compose file (Now you can use a software like postman to access to endpoints. e.g. http://localhost:5050/utils/file/extension/ )
- Exclude files generated from Jetbrains programs