### PR TITLE
Fix file extension being identified as .bin

### DIFF
--- a/doctor/views.py
+++ b/doctor/views.py
@@ -257,7 +257,7 @@ def extract_extension(request) -> HttpResponse:
             extension = ".wpd"
 
     # The extension is .bin, look in the content if we can infer the
-    # content type as pdf
+    # content type as pdf. See: https://bugs.astron.com/view.php?id=446
     if extension == ".bin":
         # Check if %PDF-X.X is in the first 1024 bytes of content
         pattern = rb"%PDF-[0-9]+(\.[0-9]+)?"

--- a/doctor/views.py
+++ b/doctor/views.py
@@ -264,6 +264,16 @@ def extract_extension(request) -> HttpResponse:
         mime = magic.from_buffer(content.strip(b"%%EOF\r"), mime=True)
         extension = mimetypes.guess_extension(mime)
 
+    # The extension is still .bin, look in the content if we can infer the
+    # content type
+    if extension == ".bin":
+        # Check if %PDF-X.X is in the first 1024 bytes of content
+        pattern = rb'%PDF-[0-9]+(\.[0-9]+)?'
+        matches = re.search(pattern, content[:1024])
+        if matches:
+            # Document contains a pdf version, so the file must be a pdf
+            extension = ".pdf"
+
     fixes = {
         ".htm": ".html",
         ".xml": ".html",

--- a/doctor/views.py
+++ b/doctor/views.py
@@ -10,10 +10,10 @@ import img2pdf
 import magic
 import pytesseract
 import requests
-from PIL import Image
-from PyPDF2 import PdfReader, PdfWriter
 from django.core.exceptions import BadRequest
 from django.http import FileResponse, HttpResponse, JsonResponse
+from PIL import Image
+from PyPDF2 import PdfReader, PdfWriter
 from pytesseract import Output
 
 from doctor.forms import (
@@ -255,14 +255,9 @@ def extract_extension(request) -> HttpResponse:
             extension = ".pdf"
         else:
             extension = ".wpd"
-    # We started seeing PDFs with whitespace in the bytes at the beginning
-    # of the file. Removing the \r from the file helps identify it correctly.
-    if extension == ".bin":
-        mime = magic.from_buffer(content.strip(b"%%EOF\r"), mime=True)
-        extension = mimetypes.guess_extension(mime)
 
-    # The extension is still .bin, look in the content if we can infer the
-    # content type
+    # The extension is .bin, look in the content if we can infer the
+    # content type as pdf
     if extension == ".bin":
         # Check if %PDF-X.X is in the first 1024 bytes of content
         pattern = rb"%PDF-[0-9]+(\.[0-9]+)?"

--- a/doctor/views.py
+++ b/doctor/views.py
@@ -1,23 +1,20 @@
-import os
+import mimetypes
 import re
-from http.client import BAD_REQUEST, INTERNAL_SERVER_ERROR
+import shutil
+from http.client import BAD_REQUEST
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Union
 
+import eyed3
 import img2pdf
 import magic
-import mimetypes
 import pytesseract
 import requests
-import shutil
-from django.http import FileResponse, HttpResponse, JsonResponse
 from PIL import Image
 from PyPDF2 import PdfReader, PdfWriter
-from pytesseract import Output
-import eyed3
-import json
-
 from django.core.exceptions import BadRequest
+from django.http import FileResponse, HttpResponse, JsonResponse
+from pytesseract import Output
 
 from doctor.forms import (
     AudioForm,
@@ -30,27 +27,27 @@ from doctor.forms import (
 from doctor.lib.utils import (
     cleanup_form,
     make_page_with_text,
-    make_png_thumbnails,
     make_png_thumbnail_for_instance,
+    make_png_thumbnails,
     strip_metadata_from_path,
 )
 from doctor.tasks import (
     convert_tiff_to_pdf_bytes,
     convert_to_mp3,
     download_images,
-    get_document_number_from_pdf,
     extract_from_doc,
     extract_from_docx,
     extract_from_html,
     extract_from_pdf,
     extract_from_txt,
     extract_from_wpd,
+    get_document_number_from_pdf,
     get_page_count,
+    get_xray,
     make_pdftotext_process,
     rasterize_pdf,
     set_mp3_meta_data,
     strip_metadata_from_bytes,
-    get_xray,
 )
 
 
@@ -268,7 +265,7 @@ def extract_extension(request) -> HttpResponse:
     # content type
     if extension == ".bin":
         # Check if %PDF-X.X is in the first 1024 bytes of content
-        pattern = rb'%PDF-[0-9]+(\.[0-9]+)?'
+        pattern = rb"%PDF-[0-9]+(\.[0-9]+)?"
         matches = re.search(pattern, content[:1024])
         if matches:
             # Document contains a pdf version, so the file must be a pdf


### PR DESCRIPTION
This issue is related to: https://github.com/freelawproject/courtlistener/issues/2688

The problem is because the Seventh Circuit of Appeals in the United States is adding additional information to PDF files, the problem is that their documents that do not comply with the PDF specification, adding new information:

![image](https://user-images.githubusercontent.com/6474994/235798569-590b8e94-072b-4485-9912-354711521a4d.png)

You can see the pdf file here: http://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&Path=Y2023/D04-27/C:22-2500:J:Brennan:aut:T:fnOp:N:3036932:S:0

This causes python-magic to be unable to identify the correct content type(application/octet-stream instead of application/pdf) and therefore not to detect the file extension correctly.

To solve this i updated the microservice that takes care of detecting file extensions by selecting the first 1024 bytes and looking for the pdf version using a regex to match "%PDF-X.X" where X.X is the version, e.g. %PDF=1.6
