### PR TITLE
fix(ci): Use newer 'docker compose' command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         echo 'DEBUG=on' >> .env.dev
 
     - name: Build Image
-      run: docker-compose -f docker-compose.dev.yml up --build -d
+      run: docker compose -f docker-compose.dev.yml up --build -d
 
     - name: Run tests
       run: docker exec mock_web_app python3 -m unittest doctor.tests

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -5,11 +5,11 @@ application that calls to this service.
 
 To build the microservice and start it up, run:
 
-    docker-compose -f docker-compose.dev.yml up --build -d
+    docker compose -f docker-compose.dev.yml up --build -d
 
 To see logs:
 
-    docker-compose -f docker-compose.dev.yml logs -f
+    docker compose -f docker-compose.dev.yml logs -f
 
 If you want to see debug logs, set `DEBUG` to `True` in `settings.py`.
 


### PR DESCRIPTION
Tests just failed on my PR #202 with the below error, which I also see occurred April 30 in [the latest run on master](https://github.com/freelawproject/doctor/actions/runs/14762765605/job/41447162822)

```
/...sh: line 1: docker-compose: command not found
```

Docker rolled out Docker Compose v2 in 2022, with its integrated `docker compose` command (no dash). The dashed version, `docker-compose`, was removed at some point, and GitHub Actions must have updated its image at some point to include the new version only.

This PR updates all `docker-compose` commands to use `docker compose`. The tests still fail with an error around changed expected content, which I will continue to investigate.