### PR TITLE
fix(ci): Expect newer extracted text

### DIFF
--- a/doctor/tests.py
+++ b/doctor/tests.py
@@ -50,7 +50,7 @@ class RECAPExtractionTests(unittest.TestCase):
             response.json()["extracted_by_ocr"], msg="Not extracted correctly"
         )
         self.assertEqual(
-            "aséakOS- 08-0220 A25BA  BAD GDoonene 2627  Filed  OL/2B/DE0IP adgeahefi2of 2",
+            "aséakOS- 08-0220 A25BA  BAD Gooonene 2627  Filed!  OL/2B/DE0IP ageahefi2of 2",
             first_line,
             msg="Wrong Text",
         )


### PR DESCRIPTION
⚠ Stacked PR, merge #203 to `main` first.

Following #203, fix the test failure.

I think this test is due to a newer version of tesseract being picked up. The `Dockerfile` installs it from apt without a pinned version:

https://github.com/freelawproject/doctor/blob/2904e2b9a7aa722633962f985a2b329e57b95426/docker/Dockerfile#L7

So, a new version with updated output has likely been released, failing the test.

The test in question reads this doubled-up text:

<img width="1093" alt="Xnapper-2025-05-06-14 33 19" src="https://github.com/user-attachments/assets/5db269ad-df38-4c27-8d4f-bd81daec93b1" />

So it's no surprise OCR fails to output anything sensible there.