### PR TITLE
fix(docker): Remove outdated compose version numbers

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   doctor:
     container_name: doctor


### PR DESCRIPTION
Copy of https://github.com/freelawproject/courtlistener/pull/5513 for this repository.

(Tests will fail until #203 and #204 are merged.)