### PR TITLE
 python-magic Incorrectly Classifies HTML as text/plain #207

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Coming up
- - Override mime type for HTML content detection
+ - Override mime type for HTML content detection #207
+
 ## Current
 
 **0.3.1 - 2023-01-17**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Coming up
+ - Override mime type for HTML content detection
 ## Current
 
 **0.3.1 - 2023-01-17**

--- a/doctor/views.py
+++ b/doctor/views.py
@@ -316,9 +316,13 @@ def extract_extension(request) -> HttpResponse:
         r"(Audio file with ID3.*MPEG.*layer III)|(.*Audio Media.*)", file_str
     ):
         mime = "audio/mpeg"
+        # If the file content contains HTML tags, override the detected mime type to text/html
+    elif b"<html" in content.lower() or b"<div" in content.lower():
+        mime = "text/html"
     else:
         # No workaround necessary
         mime = magic.from_buffer(content, mime=True)
+
     extension = mimetypes.guess_extension(mime)
     if extension == ".obj":
         # It could be a wpd, if it's not a PDF


### PR DESCRIPTION
This pull request introduces a new feature to improve MIME type detection for HTML content in the `extract_extension` function and updates the `CHANGELOG.md` to document this change.

### MIME Type Detection Enhancements:
* [`doctor/views.py`](diffhunk://#diff-de5f9b44d2bc790d6d7db03e68ddbb544ffcee53c83561880b1e7cf73799c80cR319-R325): Added logic to override the MIME type to `text/html` if the file content contains HTML tags (e.g., `<html>` or `<div>`), ensuring more accurate content type detection.

### Documentation Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R3): Added an entry under the "Coming up" section to document the new MIME type override feature for HTML content detection.