### PR TITLE
chore(ci): Rename lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  black:
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2-beta


### PR DESCRIPTION
The name 'black' is misleading, as the job runs all pre-commit hooks, and Black was even removed in 92527fad35ad0573bb8b41a9f521afc7cdc6becd.