### PR TITLE
chore(docker): Remove apt-get Retries option

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /uvx /bin/
 # caching: https://docs.docker.com/build/cache/optimize/#use-cache-mounts
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update --option "Acquire::Retries=3" --quiet=2 && \
+    apt-get update --quiet=2 && \
     apt-get install -y --no-install-recommends apt-utils && \
     apt-get install -y \
         build-essential \
@@ -23,7 +23,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         tesseract-ocr \
         && \
     apt-get install \
-        --option "Acquire::Retries=3" \
         --no-install-recommends \
         --assume-yes \
         --quiet=2 \


### PR DESCRIPTION
The default was changed to 3 in apt 2.3.2 (2021): https://salsa.debian.org/apt-team/apt/-/blob/main/debian/changelog\#L1708-1711