### PR TITLE
Remove dead temp-file write in image_to_pdf

### DIFF
--- a/doctor/views.py
+++ b/doctor/views.py
@@ -87,10 +87,7 @@ def image_to_pdf(request) -> HttpResponse:
         image = Image.open(fp)
         pdf_bytes = convert_tiff_to_pdf_bytes(image)
         cleaned_pdf_bytes = strip_metadata_from_bytes(pdf_bytes)
-        with NamedTemporaryFile(suffix=".pdf") as output:
-            with open(output.name, "wb") as f:
-                f.write(cleaned_pdf_bytes)
-            return HttpResponse(cleaned_pdf_bytes)
+        return HttpResponse(cleaned_pdf_bytes)
     finally:
         cleanup_form(form)
 


### PR DESCRIPTION
This looks like a _locally_ correct change, so long as we aren't triggering something else on the creation of this file. 