### PR TITLE
fix(memory) concurrency limits on async downloads

### DIFF
--- a/doctor/tasks.py
+++ b/doctor/tasks.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import io
+import logging
 import os
 import re
 from collections.abc import ByteString
@@ -33,6 +34,8 @@ from doctor.lib.utils import (
     ocr_needed,
     smart_text,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def pdf_bytes_from_images(image_list: list[Image]):
@@ -442,21 +445,51 @@ async def extract_from_wpd(path: str) -> tuple[str, bytes, int]:
     return content, err, process.returncode
 
 
-async def download_images(sorted_urls) -> list:
-    """Download images and convert to list of PIL images
+MAX_IMAGE_BYTES = 100 * 1024 * 1024  # 100 MB per image
+MAX_CONCURRENT_IMAGE_DOWNLOADS = 10
 
-    Once in an array of PIL.images we can easily convert this to a PDF.
+
+async def download_images(sorted_urls, dest_dir: str) -> list[str]:
+    """Stream images to ``dest_dir`` and return their paths in input order.
+
+    Caps concurrent downloads so a many-URL batch can't fan out an
+    unbounded number of in-flight requests. Each response is streamed
+    straight to disk so no image's bytes sit in RAM during the fetch.
+    Files larger than ``MAX_IMAGE_BYTES`` are still kept, but logged with
+    their final size and URL because img2pdf will load each one back
+    into memory when it builds the PDF.
 
     :param sorted_urls: List of sorted URLs for split financial disclosure
-    :return: image_list
+    :param dest_dir: Directory to write downloaded images into. The
+        caller owns its lifecycle (typically a ``TemporaryDirectory``).
+    :return: Filesystem paths of each image, in the same order as
+        ``sorted_urls``
     """
+    sem = asyncio.Semaphore(MAX_CONCURRENT_IMAGE_DOWNLOADS)
 
-    image_list = []
+    async def _fetch(client: AsyncClient, index: int, url: str) -> str:
+        path = os.path.join(dest_dir, f"{index:06d}")
+        size = 0
+        async with sem, client.stream("GET", url) as response:
+            with open(path, "wb") as f:
+                async for chunk in response.aiter_bytes():
+                    f.write(chunk)
+                    size += len(chunk)
+        if size > MAX_IMAGE_BYTES:
+            logger.warning(
+                "Image at %s is %s bytes, exceeding limit of %s; "
+                "img2pdf will load the full file into memory during "
+                "PDF construction",
+                url,
+                size,
+                MAX_IMAGE_BYTES,
+            )
+        return path
+
     async with AsyncClient(http2=True, follow_redirects=True) as client:
-        futures = [client.get(url) for url in sorted_urls]
-        for response in await asyncio.gather(*futures):
-            image_list.append(response.content)
-    return image_list
+        return await asyncio.gather(
+            *(_fetch(client, i, url) for i, url in enumerate(sorted_urls))
+        )
 
 
 # Audio

--- a/doctor/views.py
+++ b/doctor/views.py
@@ -529,11 +529,12 @@ async def images_to_pdf(request) -> HttpResponse:
     sorted_urls = form.cleaned_data["sorted_urls"]
 
     if len(sorted_urls) > 1:
-        image_list = await download_images(sorted_urls)
-        with NamedTemporaryFile(suffix=".pdf") as tmp:
-            with open(tmp.name, "wb") as f:
-                f.write(img2pdf.convert(image_list))
-            cleaned_pdf_bytes = strip_metadata_from_path(tmp.name)
+        with TemporaryDirectory() as image_dir:
+            image_paths = await download_images(sorted_urls, image_dir)
+            with NamedTemporaryFile(suffix=".pdf") as tmp:
+                with open(tmp.name, "wb") as f:
+                    img2pdf.convert(image_paths, outputstream=f)
+                cleaned_pdf_bytes = strip_metadata_from_path(tmp.name)
     else:
         tiff_image = Image.open(
             requests.get(sorted_urls[0], stream=True, timeout=60 * 5).raw


### PR DESCRIPTION
This bounds memory consumption by 10x chunk size, instead of potentially holding all of the images in memory at the same time. img2pdf loads the images in memory one at a time while processing them, and there's no way to get around that without rewriting it that I can see. Added a log warning on large file consumption so if we see that before OOMs we'll at least have an indicator that we'd get something from searching for another pdf gen library. 