### PR TITLE
docs(github): add PR template with AI disclosure section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Fixes
+<!-- What issues does this fix? Use this syntax to auto-close the issue: -->
+<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
+<!-- E.g.: "Fixes: #XYZ" -->
+This fixes...
+
+## Summary
+<!-- What does this change, how did you approach it, and are there any gotchas or compromises? -->
+This PR...
+
+## AI Disclosure
+<!-- Please check the one box that applies. -->
+- [ ] No AI tools were used to create the content of this PR.
+- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
+
+<!-- Thank you for contributing and filling out this form! -->


### PR DESCRIPTION
Adds the repo's first PR template, with Fixes, Summary, and AI Disclosure sections. The AI Disclosure section asks contributors to assert either that no AI tools were used, or that they have carefully reviewed all AI-assisted content and take full responsibility for it. The wording matches the template already adopted in courtlistener and free.law.

Test plan:

- [ ] GitHub resolves PR templates from the base branch, so this can't be verified on this PR — the next PR opened after merge should render the template.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)