### PR TITLE
fix(views): delete temp upload files on every exit path

### DIFF
--- a/doctor/lib/utils.py
+++ b/doctor/lib/utils.py
@@ -217,7 +217,7 @@ async def make_png_thumbnails(filepath, max_dimension, pages, directory):
             str(max_dimension),
             filepath,
             "-png",
-            f"{directory.name}/thumb-{page}",
+            f"{directory}/thumb-{page}",
         ]
         p = await asyncio.create_subprocess_exec(
             *command,
@@ -279,15 +279,19 @@ def strip_metadata_from_bytes(pdf_bytes):
 
 
 def cleanup_form(form):
-    """Clean up a form object
+    """Delete the temp file a form wrote during validation, if any.
 
-    When this function is called with a DocumentForm or a form that inherits from BaseFileForm, it only needs to be
-    called at the end of the view, since the file field is required, if the validation fails, the file is not created.
+    Forms that accept uploads write them to a NamedTemporaryFile(delete=False)
+    during cleaning and store the path in cleaned_data["fp"], so deleting the
+    file is the view's job. Every temp-owning view must call this in a
+    `finally` whose `try` also encloses `form.is_valid()`: the temp file can
+    exist even when validation fails or raises (the path is recorded before
+    the upload is streamed into it), so cleanup must run on every exit path.
 
-    It is necessary to call the function when using MimeForm because when form validation fails because the field is
-    not required, and the temporary file may have been created despite the failure.
+    Safe to call at any point after the form is constructed, including before
+    or partway through validation.
     """
-    fp = form.cleaned_data.get("fp")
+    fp = getattr(form, "cleaned_data", {}).get("fp")
     if fp:
         try:
             os.remove(fp)

--- a/doctor/tests.py
+++ b/doctor/tests.py
@@ -449,6 +449,135 @@ class MetadataTests(unittest.TestCase):
             msg=f"Temporary file was NOT deleted: {fp}",
         )
 
+    def _capture_temp_files(self):
+        """Return (patch context manager, list) capturing NamedTemporaryFile paths"""
+        created_temp_files = []
+        real_named_temporary_file = tempfile.NamedTemporaryFile
+
+        def capture_temp_file_creation(*args, **kwargs):
+            fp = real_named_temporary_file(*args, **kwargs)
+            created_temp_files.append(fp.name)
+            return fp
+
+        patcher = patch(
+            "tempfile.NamedTemporaryFile",
+            side_effect=capture_temp_file_creation,
+        )
+        return patcher, created_temp_files
+
+    def test_temp_file_cleanup_on_extraction_error(self):
+        """Is the temp file removed when processing raises mid-request?"""
+        client = Client(raise_request_exception=False)
+
+        files = make_buffer(filename="image-pdf.pdf")
+        django_file = SimpleUploadedFile(
+            name="image-pdf.pdf",
+            content=files["file"][1],
+            content_type="application/pdf",
+        )
+
+        capture_patcher, created_temp_files = self._capture_temp_files()
+        with (
+            capture_patcher,
+            patch(
+                "doctor.views.strip_metadata_with_exiftool",
+                side_effect=Exception("exiftool blew up"),
+            ),
+        ):
+            response = client.post(
+                reverse("file-extension"),
+                data={"file": django_file},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(len(created_temp_files), 1)
+        fp = created_temp_files[0]
+        self.assertFalse(
+            os.path.exists(fp),
+            msg=f"Temporary file was NOT deleted after an error: {fp}",
+        )
+
+    def test_temp_file_cleanup_on_upload_error(self):
+        """Is the temp file removed when the upload stream dies mid-write?
+
+        A non-ValidationError raised while streaming the upload into the
+        temp file (disk full, client disconnect) escapes form.is_valid()
+        itself, after cleaned_data["fp"] was already recorded; the view's
+        finally must still delete the partially written file.
+        """
+
+        def dying_save(self, fp):
+            with open(fp, "wb") as f:
+                f.write(b"%PDF-1.4 first chunk of a scan...")
+            raise OSError(28, "No space left on device")
+
+        client = Client(raise_request_exception=False)
+        django_file = SimpleUploadedFile(
+            name="scan.pdf",
+            content=b"placeholder",
+            content_type="application/pdf",
+        )
+
+        capture_patcher, created_temp_files = self._capture_temp_files()
+        with (
+            capture_patcher,
+            patch("doctor.forms.MimeForm.temp_save_file", dying_save),
+        ):
+            response = client.post(
+                reverse("file-extension"),
+                data={"file": django_file},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(len(created_temp_files), 1)
+        fp = created_temp_files[0]
+        self.assertFalse(
+            os.path.exists(fp),
+            msg=f"Temporary file was NOT deleted after upload died: {fp}",
+        )
+
+    def test_thumbnail_directory_cleanup_on_error(self):
+        """Is the thumbnail TemporaryDirectory removed when thumbnailing fails?"""
+        client = Client(raise_request_exception=False)
+
+        created_temp_dirs = []
+        real_temporary_directory = tempfile.TemporaryDirectory
+
+        def capture_temp_dir_creation(*args, **kwargs):
+            directory = real_temporary_directory(*args, **kwargs)
+            created_temp_dirs.append(directory.name)
+            return directory
+
+        files = make_buffer(filename="image-pdf.pdf")
+        django_file = SimpleUploadedFile(
+            name="image-pdf.pdf",
+            content=files["file"][1],
+            content_type="application/pdf",
+        )
+
+        with (
+            patch(
+                "doctor.views.TemporaryDirectory",
+                side_effect=capture_temp_dir_creation,
+            ),
+            patch(
+                "doctor.views.make_png_thumbnails",
+                side_effect=Exception("pdftoppm blew up"),
+            ),
+        ):
+            response = client.post(
+                reverse("thumbnails"),
+                data={"file": django_file, "pages": json.dumps([1])},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(len(created_temp_dirs), 1)
+        directory = created_temp_dirs[0]
+        self.assertFalse(
+            os.path.exists(directory),
+            msg=f"Temporary directory was NOT deleted after an error: {directory}",
+        )
+
 
 def test_embedding_text_to_image_pdf(self):
     """Can we embed text into an image PDF?"""

--- a/doctor/views.py
+++ b/doctor/views.py
@@ -80,12 +80,12 @@ def image_to_pdf(request) -> HttpResponse:
     """
 
     form = DocumentForm(request.POST, request.FILES)
-    if not form.is_valid():
-        return HttpResponse("Failed validation", status=BAD_REQUEST)
-
-    fp = form.cleaned_data["fp"]
-
     try:
+        if not form.is_valid():
+            return HttpResponse("Failed validation", status=BAD_REQUEST)
+
+        fp = form.cleaned_data["fp"]
+
         image = Image.open(fp)
         pdf_bytes = convert_tiff_to_pdf_bytes(image)
         cleaned_pdf_bytes = strip_metadata_from_bytes(pdf_bytes)
@@ -105,16 +105,15 @@ def extract_recap_document(request) -> JsonResponse:
     :return: JsonResponse
     """
     form = DocumentForm(request.GET, request.FILES)
-    if not form.is_valid():
-        return JsonResponse(
-            {
-                "err": "Failed validation",
-            },
-            status=BAD_REQUEST,
-        )
-    filepath = form.cleaned_data["fp"]
-
     try:
+        if not form.is_valid():
+            return JsonResponse(
+                {
+                    "err": "Failed validation",
+                },
+                status=BAD_REQUEST,
+            )
+        filepath = form.cleaned_data["fp"]
         strip_margin = form.cleaned_data["strip_margin"]
         content, extracted_by_ocr = extract_recap_pdf(
             filepath=filepath,
@@ -139,82 +138,84 @@ async def extract_doc_content(request) -> JsonResponse | HttpResponse:
     :type: json object
     """
     form = DocumentForm(request.GET, request.FILES)
-    if not form.is_valid():
-        return HttpResponse("Failed validation", status=BAD_REQUEST)
-    ocr_available = form.cleaned_data["ocr_available"]
-    extension = form.cleaned_data["extension"]
-    fp = form.cleaned_data["fp"]
-    extracted_by_ocr = False
-    err = ""
-    # We keep the original file name to use it for debugging purposes, you can find it in local_path (Opinion) field
-    # or filepath_local (AbstractPDF).
-    original_filename = form.cleaned_data["original_filename"]
     try:
-        if extension == "pdf":
-            (
-                content,
-                err,
-                returncode,
-                extracted_by_ocr,
-            ) = await extract_from_pdf(fp, ocr_available)
-        elif extension == "doc":
-            content, err, returncode = await extract_from_doc(fp)
-        elif extension == "docx":
-            content, err, returncode = await extract_from_docx(fp)
-        elif extension == "html":
-            content, err, returncode = extract_from_html(fp)
-        elif extension == "txt":
-            content, err, returncode = extract_from_txt(fp)
-        elif extension == "wpd":
-            content, err, returncode = await extract_from_wpd(fp)
-        else:
-            returncode = 1
-            err = "Unable to extract content due to unknown extension"
-            content = ""
+        if not form.is_valid():
+            return HttpResponse("Failed validation", status=BAD_REQUEST)
+        ocr_available = form.cleaned_data["ocr_available"]
+        extension = form.cleaned_data["extension"]
+        fp = form.cleaned_data["fp"]
+        extracted_by_ocr = False
+        err = ""
+        # We keep the original file name to use it for debugging purposes, you can find it in local_path (Opinion) field
+        # or filepath_local (AbstractPDF).
+        original_filename = form.cleaned_data["original_filename"]
+        try:
+            if extension == "pdf":
+                (
+                    content,
+                    err,
+                    returncode,
+                    extracted_by_ocr,
+                ) = await extract_from_pdf(fp, ocr_available)
+            elif extension == "doc":
+                content, err, returncode = await extract_from_doc(fp)
+            elif extension == "docx":
+                content, err, returncode = await extract_from_docx(fp)
+            elif extension == "html":
+                content, err, returncode = extract_from_html(fp)
+            elif extension == "txt":
+                content, err, returncode = extract_from_txt(fp)
+            elif extension == "wpd":
+                content, err, returncode = await extract_from_wpd(fp)
+            else:
+                returncode = 1
+                err = "Unable to extract content due to unknown extension"
+                content = ""
 
-        if returncode != 0:
+            if returncode != 0:
+                log_sentry_event(
+                    logger=logger,
+                    level=logging.ERROR,
+                    message="Unable to extract document content",
+                    extra={
+                        "file_name": original_filename,
+                        "err": err,
+                    },
+                    exc_info=True,
+                )
+                pass
+
+        except (XMLSyntaxError, ParserError) as e:
+            error_message = "HTML cleaning failed due to ParserError."
+            if isinstance(e, XMLSyntaxError):
+                error_message = "HTML cleaning failed due to XMLSyntaxError."
+
             log_sentry_event(
                 logger=logger,
                 level=logging.ERROR,
-                message="Unable to extract document content",
+                message=error_message,
                 extra={
                     "file_name": original_filename,
-                    "err": err,
+                    "exception_type": type(e).__name__,
+                    "exception_message": str(e),
                 },
                 exc_info=True,
             )
-            pass
+            content = "Unable to extract the content from this file. Please try reading the original."
 
-    except (XMLSyntaxError, ParserError) as e:
-        error_message = "HTML cleaning failed due to ParserError."
-        if isinstance(e, XMLSyntaxError):
-            error_message = "HTML cleaning failed due to XMLSyntaxError."
-
-        log_sentry_event(
-            logger=logger,
-            level=logging.ERROR,
-            message=error_message,
-            extra={
-                "file_name": original_filename,
-                "exception_type": type(e).__name__,
-                "exception_message": str(e),
-            },
-            exc_info=True,
+        # Get page count if you can
+        page_count = get_page_count(fp, extension)
+        return JsonResponse(
+            {
+                "content": content,
+                "err": err,
+                "extension": extension,
+                "extracted_by_ocr": extracted_by_ocr,
+                "page_count": page_count,
+            }
         )
-        content = "Unable to extract the content from this file. Please try reading the original."
-
-    # Get page count if you can
-    page_count = get_page_count(fp, extension)
-    cleanup_form(form)
-    return JsonResponse(
-        {
-            "content": content,
-            "err": err,
-            "extension": extension,
-            "extracted_by_ocr": extracted_by_ocr,
-            "page_count": page_count,
-        }
-    )
+    finally:
+        cleanup_form(form)
 
 
 @log_upload_lifecycle
@@ -250,22 +251,22 @@ async def make_png_thumbnails_from_range(request) -> HttpResponse:
     if not form.is_valid():
         return HttpResponse("Failed validation", status=BAD_REQUEST)
 
-    directory = TemporaryDirectory()
-    with NamedTemporaryFile(suffix=".pdf", mode="r+b") as temp_pdf:
-        temp_pdf.write(form.cleaned_data["file"].read())
+    with TemporaryDirectory() as directory:
+        with NamedTemporaryFile(suffix=".pdf", mode="r+b") as temp_pdf:
+            temp_pdf.write(form.cleaned_data["file"].read())
 
-        await make_png_thumbnails(
-            temp_pdf.name,
-            form.cleaned_data["max_dimension"],
-            form.cleaned_data["pages"],
-            directory,
-        )
+            await make_png_thumbnails(
+                temp_pdf.name,
+                form.cleaned_data["max_dimension"],
+                form.cleaned_data["pages"],
+                directory,
+            )
 
-    with NamedTemporaryFile(suffix=".zip") as tmp_zip:
-        filename = shutil.make_archive(
-            f"{tmp_zip.name[:-4]}", "zip", directory.name
-        )
-        return FileResponse(open(filename, "rb"))
+        with NamedTemporaryFile(suffix=".zip") as tmp_zip:
+            filename = shutil.make_archive(
+                f"{tmp_zip.name[:-4]}", "zip", directory
+            )
+            return FileResponse(open(filename, "rb"))
 
 
 @log_upload_lifecycle
@@ -302,12 +303,11 @@ def page_count(request) -> HttpResponse:
     :return: Page count
     """
     form = DocumentForm(request.POST, request.FILES)
-    if not form.is_valid():
-        return HttpResponse("Failed validation", status=BAD_REQUEST)
-
-    fp = form.cleaned_data["fp"]
-
     try:
+        if not form.is_valid():
+            return HttpResponse("Failed validation", status=BAD_REQUEST)
+
+        fp = form.cleaned_data["fp"]
         extension = form.cleaned_data["extension"]
         pg_count = get_page_count(fp, extension)
         return HttpResponse(pg_count)
@@ -324,14 +324,12 @@ async def extract_mime_type(request) -> JsonResponse | HttpResponse:
     :return: MIME type as JSON
     """
     form = MimeForm(request.GET, request.FILES)
-    if not form.is_valid():
-        # Not valid, try to remove file
-        cleanup_form(form)
-        return HttpResponse("Failed validation", status=BAD_REQUEST)
-
-    fp = form.cleaned_data["fp"]
-
     try:
+        if not form.is_valid():
+            return HttpResponse("Failed validation", status=BAD_REQUEST)
+
+        fp = form.cleaned_data["fp"]
+
         await strip_metadata_with_exiftool(fp)
 
         with open(fp, "rb") as f:
@@ -382,12 +380,12 @@ async def extract_extension(request) -> HttpResponse:
     :returns: the file extension as plain text
     """
     form = MimeForm(request.GET, request.FILES)
-    if not form.is_valid():
-        return HttpResponse("Failed validation", status=BAD_REQUEST)
-
-    fp = form.cleaned_data["fp"]
-
     try:
+        if not form.is_valid():
+            return HttpResponse("Failed validation", status=BAD_REQUEST)
+
+        fp = form.cleaned_data["fp"]
+
         # avoid "referenced before assignment" warnings from analyzer
         content = b""
 
@@ -587,10 +585,10 @@ async def convert_audio(
     :return: Converted audio
     """
     form = AudioForm(request.GET, request.FILES)
-    if not form.is_valid():
-        return HttpResponse("Failed validation", status=BAD_REQUEST)
-
     try:
+        if not form.is_valid():
+            return HttpResponse("Failed validation", status=BAD_REQUEST)
+
         filepath = form.cleaned_data["fp"]
         media_file = form.cleaned_data["file"]
         audio_data = {k: v[0] for k, v in dict(request.GET).items()}
@@ -618,11 +616,11 @@ async def embed_text(request) -> FileResponse | HttpResponse:
     :return: Embedded PDF
     """
     form = DocumentForm(request.GET, request.FILES)
-    if not form.is_valid():
-        return HttpResponse("Failed validation", status=BAD_REQUEST)
-    fp = form.cleaned_data["fp"]
-
     try:
+        if not form.is_valid():
+            return HttpResponse("Failed validation", status=BAD_REQUEST)
+        fp = form.cleaned_data["fp"]
+
         with NamedTemporaryFile(suffix=".tiff") as destination:
             await rasterize_pdf(fp, destination.name)
             data = pytesseract.image_to_data(
@@ -662,14 +660,14 @@ def get_document_number(request) -> HttpResponse:
     """
 
     form = BaseFileForm(request.GET, request.FILES)
-    if not form.is_valid():
-        validation_message = form.errors.get_json_data()["__all__"][0][
-            "message"
-        ]
-        return HttpResponse(validation_message, status=BAD_REQUEST)
-    fp = form.cleaned_data["fp"]
-
     try:
+        if not form.is_valid():
+            validation_message = form.errors.get_json_data()["__all__"][0][
+                "message"
+            ]
+            return HttpResponse(validation_message, status=BAD_REQUEST)
+        fp = form.cleaned_data["fp"]
+
         document_number = get_document_number_from_pdf(fp)
         return HttpResponse(document_number)
     finally:


### PR DESCRIPTION
## Fixes
Fixes: #242

## Summary
- Standardize all temp-owning views on the `xray` shape: `form.is_valid()` is now the first statement inside the `try`, with `cleanup_form(form)` in the `finally`, so the temp file written during validation is deleted on success, on failed validation, and on any exception — including ones that escape `is_valid()` itself (e.g. `OSError` while streaming the upload). Affected views: `image_to_pdf`, `extract_recap_document`, `extract_doc_content`, `page_count`, `extract_mime_type`, `extract_extension`, `embed_text`, `get_document_number`.
- `extract_doc_content` previously cleaned up only on the success path — any failure in extraction or `get_page_count` leaked the upload on the busiest endpoint.
- Also move `convert_audio`'s validation inside its `try` for consistency (no leak today, since `AudioForm` doesn't write a file during validation), and drop `extract_mime_type`'s now-redundant defensive cleanup on the invalid branch.
- Context-manage the `TemporaryDirectory` in `make_png_thumbnails_from_range` instead of relying on GC finalizers; `make_png_thumbnails` now receives the directory path string.
- Harden `cleanup_form` with `getattr(form, "cleaned_data", {})` so it's safe on partially validated forms, and rewrite its docstring — the old one documented the fragile "only call at end of view" invariant this PR removes.
- Add three regression tests beside `test_temp_file_cleanup`: extraction raising mid-request, the upload stream dying mid-write after `cleaned_data["fp"]` is recorded (the issue's reproduction, simulated by patching `temp_save_file` since the test client rebuilds uploads server-side), and thumbnail-directory removal when `make_png_thumbnails` fails.
- Out of scope, per the issue: deleting dead `pdf_to_text` (separate PR), and `convert_pdf_bitonal` from #241, which already has the correct shape.

## AI Disclosure
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)