### PR TITLE
fix(docker): bind published dev ports to localhost

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
         options: --reload
     image: freelawproject/doctor:latest
     ports:
-      - 5050:5050
+      - 127.0.0.1:5050:5050
     volumes:
       - .:/opt/app
     env_file:


### PR DESCRIPTION
## Fixes
Follow-up to freelawproject/courtlistener#7879; no linked issue.

## Summary
Binds the published port in the dev compose file (`5050:5050`) to 127.0.0.1 instead of all interfaces. The README's `docker run -p 5050:5050` examples describe running the published image and are left alone.

Without this, anyone on the same network as a dev machine — coworking space, café Wi-Fi — can connect directly to these dev services. The host firewall doesn't help, because Docker inserts its own iptables rules ahead of it. On a machine with a public IP (no NAT), the ports are open to the internet.

Nothing changes for normal development: host-side connections to the same localhost ports work as before, and container-to-container traffic uses Docker's internal network, not these bindings. Anyone who wants a port reachable from another device can rebind it in a personal docker-compose.override.yml.

Follow-up to freelawproject/courtlistener#7879. Input welcome.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRTCnUPQL9v5Lv5L5Vo9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRTCnUPQL9v5Lv5L5Vo9)_