### PR TITLE
OCR PDFs in fixed-size page slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Features:
    `DOCTOR_BITONAL_PAGE_TIMEOUT_MAX_SECONDS` (default 200) caps the former.
    A failure on a page reports `page_number`, `pages_completed`,
    `elapsed_ms`, `pixels` and `timeout_limit` as JSON fields.
+ - OCR (`/extract/doc/text/` with `ocr_available`) rasterizes and OCRs a
+   PDF in slices of `DOCTOR_OCR_PAGES_PER_SLICE` pages (default 25) instead
+   of rendering the whole document to one TIFF, so a request's peak memory
+   and `/tmp` usage depend on the slice size rather than the page count. A
+   914-page scanned record was OOM-killing the 500 MB pod. Documents that
+   fit in one slice take a single pass, and the text is identical either
+   way. Each slice logs its page range, duration and text length at INFO.
 
 Fixes:
  - Delegate file identification to Magika's `identify_path`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ Features:
    and `/tmp` usage depend on the slice size rather than the page count. A
    914-page scanned record was OOM-killing the 500 MB pod. Documents that
    fit in one slice take a single pass, and the text is identical either
-   way. Each slice logs its page range, duration and text length at INFO.
+   way. pypdf's page count only sets the slice boundaries: the last slice
+   renders through the real end of the file, so a document whose page tree
+   pypdf miscounts still has every page OCRed. Each slice logs its page
+   range, duration and text length at INFO.
 
 Fixes:
  - Delegate file identification to Magika's `identify_path`

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ curl 'http://localhost:5050/extract/doc/text/?ocr_available=True' \
   -F "file=@doctor/test_assets/image-pdf.pdf"
 ```
 
+OCR renders and reads the PDF in slices of `DOCTOR_OCR_PAGES_PER_SLICE`
+pages (default 25), one slice at a time, so a request's peak memory and
+`/tmp` usage are set by the slice size rather than by the document's page
+count. Lower it if pods with several concurrent OCR requests run out of
+memory; raise it to spend fewer ghostscript and tesseract invocations on
+large documents. The extracted text is the same whatever the value.
+
 Magic:
 
  - The mimetype of the file will be determined by the name of the file you pass in. For example, if you pass in medical_assessment.pdf, the `pdf` extractor will be used.

--- a/doctor/settings.py
+++ b/doctor/settings.py
@@ -66,6 +66,14 @@ DOCTOR_BITONAL_MAX_DOWNLOAD_BYTES = env.int(
     "DOCTOR_BITONAL_MAX_DOWNLOAD_BYTES", default=1024**3
 )
 
+# OCR runs ghostscript and tesseract over this many pages at a time, so a
+# request's peak memory and /tmp usage depend on the slice size rather
+# than on the document's page count. A 300 DPI letter page is ~8 MB of
+# grayscale pixels; the pod limit, the idle worker's footprint and the
+# expected concurrency decide how many of those fit. Documents with no
+# more pages than this take a single pass, exactly as before.
+DOCTOR_OCR_PAGES_PER_SLICE = env.int("DOCTOR_OCR_PAGES_PER_SLICE", default=25)
+
 SENTRY_DSN = env("SENTRY_DSN", default="")
 if SENTRY_DSN:
     sentry_sdk.init(

--- a/doctor/tasks.py
+++ b/doctor/tasks.py
@@ -3,6 +3,7 @@ import base64
 import fnmatch
 import hashlib
 import io
+import logging
 import os
 import re
 import time
@@ -40,6 +41,8 @@ from doctor.lib.utils import (
     ocr_needed,
     smart_text,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def pdf_bytes_from_images(image_list: list[Image]):
@@ -84,13 +87,23 @@ async def make_pdftotext_process(path):
     return content.decode(), err, process.returncode
 
 
-async def rasterize_pdf(path, destination):
-    """Convert the PDF into a multipage Tiff file.
+async def rasterize_pdf(
+    path: str,
+    destination: str,
+    first_page: int | None = None,
+    last_page: int | None = None,
+):
+    """Convert the PDF, or a page range of it, into a multipage Tiff file.
 
     This function uses ghostscript for processing and borrows heavily from:
 
         https://github.com/jbarlow83/OCRmyPDF/blob/636d1903b35fed6b07a01af53769fea81f388b82/ocrmypdf/ghostscript.py#L11
 
+    :param path: The PDF to rasterize
+    :param destination: Where to write the TIFF
+    :param first_page: 1-based first page to render; None means page 1
+    :param last_page: 1-based last page to render; None means the last page
+    :return: ghostscript's stdout, stderr and return code
     """
     # gs docs, see: http://ghostscript.com/doc/7.07/Use.htm
     # gs devices, see: http://ghostscript.com/doc/current/Devices.htm
@@ -110,10 +123,12 @@ async def rasterize_pdf(path, destination):
         "-sDEVICE=tiffgray",
         "-sCompression=lzw",
         "-r300x300",  # Set the resolution to 300 DPI.
-        "-o",
-        destination,
-        path,
     ]
+    if first_page is not None:
+        gs.append(f"-dFirstPage={first_page}")
+    if last_page is not None:
+        gs.append(f"-dLastPage={last_page}")
+    gs += ["-o", destination, path]
 
     p = await asyncio.create_subprocess_exec(
         *gs,
@@ -225,20 +240,82 @@ async def extract_from_pdf(
     return content, err, returncode, extracted_by_ocr
 
 
-async def extract_by_ocr(path: str) -> (bool, str):
+OCR_FAIL_MSG = (
+    "Unable to extract the content from this file. Please try "
+    "reading the original."
+)
+
+# Tesseract separates the pages of a multi-page TIFF with a form feed and
+# emits none after the last page, so joining the slices with one gives the
+# same text as a single pass over the whole document.
+OCR_PAGE_SEPARATOR = "\f"
+
+
+async def extract_by_ocr(path: str) -> tuple[bool, str]:
     """Extract the contents of a PDF using OCR.
+
+    The document is rasterized and OCRed in slices of
+    ``settings.DOCTOR_OCR_PAGES_PER_SLICE`` pages, one slice at a time, so
+    ghostscript, tesseract and /tmp each hold at most one slice however
+    long the document is. A document that fits in one slice takes a
+    single pass, as does one whose page count pypdf cannot read.
 
     :param path: The path to the file
     :return Tuple with success or fail boolean and text
     """
-    fail_msg = (
-        "Unable to extract the content from this file. Please try "
-        "reading the original."
-    )
+    pages_per_slice = max(1, settings.DOCTOR_OCR_PAGES_PER_SLICE)
+    page_count = get_page_count(path, "pdf") or 0
+    if page_count <= pages_per_slice:
+        return await _ocr_page_range(path)
+
+    parts: list[str] = []
+    for first in range(1, page_count + 1, pages_per_slice):
+        last = min(first + pages_per_slice - 1, page_count)
+        started = time.monotonic()
+        success, text = await _ocr_page_range(path, first, last)
+        if not success:
+            logger.warning(
+                "OCR failed on pages %d-%d of %d of %s",
+                first,
+                last,
+                page_count,
+                path,
+            )
+            return False, OCR_FAIL_MSG
+        logger.info(
+            "OCRed pages %d-%d of %d of %s in %.1fs, %d chars",
+            first,
+            last,
+            page_count,
+            path,
+            time.monotonic() - started,
+            len(text),
+        )
+        parts.append(text)
+    return True, OCR_PAGE_SEPARATOR.join(parts)
+
+
+async def _ocr_page_range(
+    path: str,
+    first_page: int | None = None,
+    last_page: int | None = None,
+) -> tuple[bool, str]:
+    """Rasterize one page range to a temporary TIFF and OCR it.
+
+    The TIFF is removed when this returns, so only one range's worth of
+    pixels is ever on disk.
+
+    :param path: The path to the PDF
+    :param first_page: 1-based first page, None for the whole document
+    :param last_page: 1-based last page, None for the whole document
+    :return Tuple with success or fail boolean and text
+    """
     with NamedTemporaryFile(prefix="ocr_", suffix=".tiff", buffering=0) as tmp:
-        out, err, returncode = await rasterize_pdf(path, tmp.name)
+        out, err, returncode = await rasterize_pdf(
+            path, tmp.name, first_page, last_page
+        )
         if returncode != 0:
-            return False, fail_msg
+            return False, OCR_FAIL_MSG
 
         txt = await convert_file_to_txt(tmp.name)
         txt = cleanup_ocr_text(txt)

--- a/doctor/tasks.py
+++ b/doctor/tasks.py
@@ -260,38 +260,60 @@ async def extract_by_ocr(path: str) -> tuple[bool, str]:
     long the document is. A document that fits in one slice takes a
     single pass, as does one whose page count pypdf cannot read.
 
+    The slice boundaries come from pypdf's page count, but the count is
+    not trusted to be the end of the document: the last slice is left
+    open-ended so ghostscript renders every page it finds past the count,
+    and the loop stops early if ghostscript finds no pages in a slice.
+    No page is lost when pypdf and ghostscript disagree on the count.
+
     :param path: The path to the file
     :return Tuple with success or fail boolean and text
     """
     pages_per_slice = max(1, settings.DOCTOR_OCR_PAGES_PER_SLICE)
     page_count = get_page_count(path, "pdf") or 0
     if page_count <= pages_per_slice:
-        return await _ocr_page_range(path)
+        success, text = await _ocr_page_range(path)
+        return success, text or ""
 
     parts: list[str] = []
     for first in range(1, page_count + 1, pages_per_slice):
-        last = min(first + pages_per_slice - 1, page_count)
+        last: int | None = first + pages_per_slice - 1
+        if last >= page_count:
+            # Render through the real end of the file, wherever it is.
+            last = None
+        last_label = last if last is not None else "end"
         started = time.monotonic()
         success, text = await _ocr_page_range(path, first, last)
         if not success:
             logger.warning(
-                "OCR failed on pages %d-%d of %d of %s",
+                "OCR failed on pages %d-%s of %d of %s",
                 first,
-                last,
+                last_label,
                 page_count,
                 path,
             )
             return False, OCR_FAIL_MSG
+        if text is None:
+            logger.warning(
+                "pypdf counted %d pages in %s but ghostscript found none "
+                "from page %d; stopping there",
+                page_count,
+                path,
+                first,
+            )
+            break
         logger.info(
-            "OCRed pages %d-%d of %d of %s in %.1fs, %d chars",
+            "OCRed pages %d-%s of %d of %s in %.1fs, %d chars",
             first,
-            last,
+            last_label,
             page_count,
             path,
             time.monotonic() - started,
             len(text),
         )
         parts.append(text)
+        if last is None:
+            break
     return True, OCR_PAGE_SEPARATOR.join(parts)
 
 
@@ -299,7 +321,7 @@ async def _ocr_page_range(
     path: str,
     first_page: int | None = None,
     last_page: int | None = None,
-) -> tuple[bool, str]:
+) -> tuple[bool, str | None]:
     """Rasterize one page range to a temporary TIFF and OCR it.
 
     The TIFF is removed when this returns, so only one range's worth of
@@ -307,8 +329,11 @@ async def _ocr_page_range(
 
     :param path: The path to the PDF
     :param first_page: 1-based first page, None for the whole document
-    :param last_page: 1-based last page, None for the whole document
-    :return Tuple with success or fail boolean and text
+    :param last_page: 1-based last page, None for the whole document; a
+        last page past the end of the document renders up to the end
+    :return (False, message) if ghostscript failed; (True, None) if the
+        range starts past the end of the document, so ghostscript rendered
+        no pages; otherwise (True, text)
     """
     with NamedTemporaryFile(prefix="ocr_", suffix=".tiff", buffering=0) as tmp:
         out, err, returncode = await rasterize_pdf(
@@ -316,6 +341,10 @@ async def _ocr_page_range(
         )
         if returncode != 0:
             return False, OCR_FAIL_MSG
+        if os.path.getsize(tmp.name) == 0:
+            # ghostscript exits 0 with no output when first_page is past
+            # the last page of the document.
+            return True, None
 
         txt = await convert_file_to_txt(tmp.name)
         txt = cleanup_ocr_text(txt)

--- a/doctor/tests.py
+++ b/doctor/tests.py
@@ -1624,6 +1624,61 @@ class OCRSlicingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(tesseract.call_count, 1)
         self.assertEqual(self.leftover_tiffs(), before)
 
+    async def test_last_slice_is_open_ended(self):
+        """Is the final slice rendered to the end of the file, not the count?
+
+        pypdf's count only sets the slice boundaries. The last slice gets
+        no last page, so ghostscript renders every page it finds there.
+        """
+        from django.test import override_settings
+
+        from doctor import tasks
+
+        calls = []
+        real_rasterize = tasks.rasterize_pdf
+
+        async def spy(path, destination, first=None, last=None):
+            calls.append((first, last))
+            return await real_rasterize(path, destination, first, last)
+
+        with (
+            override_settings(DOCTOR_OCR_PAGES_PER_SLICE=2),
+            patch("doctor.tasks.rasterize_pdf", side_effect=spy),
+        ):
+            success, text = await tasks.extract_by_ocr(self.pdf_path)
+        self.assertTrue(success)
+        self.assertEqual(calls, [(1, 2), (3, 4), (5, None)])
+        self.assertEqual(text.count(tasks.OCR_PAGE_SEPARATOR), 4)
+
+    async def test_page_count_disagreement_loses_no_pages(self):
+        """Does a wrong pypdf page count still OCR every page exactly once?
+
+        A damaged page tree can make pypdf return a count that differs from
+        what ghostscript renders. An undercount must not drop the trailing
+        pages, and an overcount must not append empty slices.
+        """
+        from django.test import override_settings
+
+        from doctor import tasks
+
+        with override_settings(DOCTOR_OCR_PAGES_PER_SLICE=100):
+            success, single = await tasks.extract_by_ocr(self.pdf_path)
+        self.assertTrue(success)
+        for marker in self.markers:
+            self.assertIn(marker, single)
+
+        before = self.leftover_tiffs()
+        for wrong_count in (3, 4, 6, 20):
+            with (
+                self.subTest(pypdf_count=wrong_count),
+                override_settings(DOCTOR_OCR_PAGES_PER_SLICE=2),
+                patch("doctor.tasks.get_page_count", return_value=wrong_count),
+            ):
+                success, sliced = await tasks.extract_by_ocr(self.pdf_path)
+                self.assertTrue(success)
+                self.assertEqual(sliced, single)
+        self.assertEqual(self.leftover_tiffs(), before)
+
 
 class TestOCRConfidenceTests(unittest.TestCase):
     """Test our OCR confidence checking functions."""

--- a/doctor/tests.py
+++ b/doctor/tests.py
@@ -24,7 +24,7 @@ import requests
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client
 from django.urls import reverse
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 from pypdf import PdfReader
 
 from doctor.lib.text_extraction import (
@@ -1499,6 +1499,130 @@ class TestRecapWhitespaceInsertions(unittest.TestCase):
         }
         result = insert_whitespace(content, word, prev)
         self.assertEqual(result, "foo")
+
+
+class OCRSlicingTests(unittest.IsolatedAsyncioTestCase):
+    """OCR runs over fixed-size page slices.
+
+    A 900-page scanned record rasterized and OCRed in one pass took the
+    pod over its memory limit; slicing bounds ghostscript, tesseract and
+    /tmp to one slice at a time. These tests build a small scanned-style
+    PDF (one image per page carrying a marker word) and force several
+    slices with a low DOCTOR_OCR_PAGES_PER_SLICE.
+    """
+
+    markers = ["ALPHA", "BRAVO", "CHARLIE", "DELTA", "ECHO"]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.TemporaryDirectory()
+        cls.pdf_path = os.path.join(cls.tmpdir.name, "scan.pdf")
+        font = ImageFont.load_default(size=48)
+        pages = []
+        for marker in cls.markers:
+            # A letter page at 150 DPI, white with one line of text.
+            page = Image.new("L", (1275, 1650), 255)
+            ImageDraw.Draw(page).text(
+                (200, 300), f"Page {marker} of the record", fill=0, font=font
+            )
+            pages.append(page)
+        pages[0].save(
+            cls.pdf_path,
+            save_all=True,
+            append_images=pages[1:],
+            resolution=150,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmpdir.cleanup()
+
+    @staticmethod
+    def leftover_tiffs():
+        return set(
+            glob.glob(os.path.join(tempfile.gettempdir(), "ocr_*.tiff"))
+        )
+
+    async def test_rasterize_page_range(self):
+        """Does a page range render exactly those pages, and no range all?"""
+        from doctor.tasks import rasterize_pdf
+
+        with NamedTemporaryFile(suffix=".tiff") as tiff:
+            _, stderr, returncode = await rasterize_pdf(
+                self.pdf_path, tiff.name, 2, 4
+            )
+            self.assertEqual(returncode, 0, msg=stderr)
+            with Image.open(tiff.name) as rendered:
+                self.assertEqual(rendered.n_frames, 3)
+
+        with NamedTemporaryFile(suffix=".tiff") as tiff:
+            _, stderr, returncode = await rasterize_pdf(
+                self.pdf_path, tiff.name
+            )
+            self.assertEqual(returncode, 0, msg=stderr)
+            with Image.open(tiff.name) as rendered:
+                self.assertEqual(rendered.n_frames, len(self.markers))
+
+    async def test_sliced_ocr_matches_single_pass(self):
+        """Do three slices produce the same text as one pass?"""
+        from django.test import override_settings
+
+        from doctor.tasks import OCR_PAGE_SEPARATOR, extract_by_ocr
+
+        before = self.leftover_tiffs()
+        # Five pages in slices of two: 1-2, 3-4, 5.
+        with override_settings(DOCTOR_OCR_PAGES_PER_SLICE=2):
+            success, sliced = await extract_by_ocr(self.pdf_path)
+        self.assertTrue(success)
+        for marker in (self.markers[0], self.markers[2], self.markers[-1]):
+            self.assertIn(marker, sliced, msg=sliced)
+        self.assertEqual(
+            sliced.count(OCR_PAGE_SEPARATOR),
+            len(self.markers) - 1,
+            msg="one separator between each pair of pages, none trailing",
+        )
+
+        with override_settings(DOCTOR_OCR_PAGES_PER_SLICE=100):
+            success, single = await extract_by_ocr(self.pdf_path)
+        self.assertTrue(success)
+        self.assertEqual(sliced, single)
+        self.assertEqual(self.leftover_tiffs(), before)
+
+    async def test_failed_slice_fails_the_document(self):
+        """Does a ghostscript failure mid-document fail cleanly?
+
+        The failure must surface as the usual (False, message) result
+        without OCRing the remaining slices, and the failed slice's TIFF
+        must not be left behind in the temp dir.
+        """
+        from django.test import override_settings
+
+        from doctor import tasks
+
+        before = self.leftover_tiffs()
+        real_rasterize = tasks.rasterize_pdf
+        calls = []
+
+        async def flaky_rasterize(path, destination, first=None, last=None):
+            calls.append((first, last))
+            if first == 3:
+                return b"", b"Unrecoverable error", 1
+            return await real_rasterize(path, destination, first, last)
+
+        with (
+            override_settings(DOCTOR_OCR_PAGES_PER_SLICE=2),
+            patch("doctor.tasks.rasterize_pdf", side_effect=flaky_rasterize),
+            patch(
+                "doctor.tasks.convert_file_to_txt",
+                wraps=tasks.convert_file_to_txt,
+            ) as tesseract,
+        ):
+            success, text = await tasks.extract_by_ocr(self.pdf_path)
+        self.assertFalse(success)
+        self.assertEqual(text, tasks.OCR_FAIL_MSG)
+        self.assertEqual(calls, [(1, 2), (3, 4)])
+        self.assertEqual(tesseract.call_count, 1)
+        self.assertEqual(self.leftover_tiffs(), before)
 
 
 class TestOCRConfidenceTests(unittest.TestCase):


### PR DESCRIPTION
This is related to the findings in https://github.com/freelawproject/infrastructure/issues/818

Found that OCRing a large document causes memory usage to grow slowly throughout the process. 

One request handled the entire document in one go. Ghostscript rendered the PDF page by page into a single TIFF file in `/tmp`, so that file grew slightly with every page rendered.

In a pod, /tmp is usually backed by memory, and files stored there count against the pod's memory limit. As a result, the pod's memory usage increased slowly as the TIFF file grew.

Then Tesseract opened the 914-page TIFF and processed it, adding its own working memory on top while the entire TIFF file was still in `/tmp`. Nothing is freed until the request finished, so memory usage continued increasing page by page until the pod crossed its 500 MB limit and was killed.

The proposed solution in this issue is slicing, each 25-page TIFF is written, processed, and deleted before the next slice starts. This keeps the memory usage per request essentially flat, regardless of how long the document is.

Here's a chart showing memory usage during the extraction of a single 914-page document (28 MB).
<img width="2160" height="1080" alt="memory_usage_trend" src="https://github.com/user-attachments/assets/d9178855-d2f5-4326-8d1e-8ed9d6aea190" />


And here is the same document extraction after the tweak:
<img width="2160" height="1080" alt="memory_usage_trend_fix" src="https://github.com/user-attachments/assets/60bb4772-7fe6-4082-90c5-1d0421e699b8" />

### Scope

* Only the PDF branch of `/extract/doc/text/` when `ocr_available` is enabled is affected. The `doc`, `docx`, `html`, `txt`, and `wpd` extractors are unchanged.
* `rasterize_pdf` now accepts an optional page range. Its other caller, `embed_text`, passes no range and therefore runs the same command as before.
* Failure semantics are unchanged: if Ghostscript fails on any slice, the entire document extraction fails, just as a single Ghostscript failure did previously.

### Tests

The new `OCRSlicingTests` build a five-page scanned-style PDF and force two-page slices. They verify that:

* Sliced extraction produces the same text as a single-pass extraction, with one separator per page break and no temporary TIFF files left behind.
* A page range renders exactly the requested pages.
* A Ghostscript failure in the middle of the document fails cleanly without OCRing the remaining slices.
* The final slice is sent without a `last_page` value.
* Page counts patched to 3, 4, 6, and 20 all produce text identical to a single-pass extraction.
